### PR TITLE
Support auto-registration of commands

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@ namespace Dunglas\ActionBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * {@inheritdoc}
@@ -31,12 +32,27 @@ class Configuration implements ConfigurationInterface
                     ->info('Autodiscover action classes stored in the configured directory of bundles and register them as service.')
                     ->canBeDisabled()
                     ->children()
-                        ->scalarNode('directory')->defaultValue('Action')->info('The directory name to autodiscover in bundles.')->end()
+                        ->arrayNode('directories')
+                            ->info('The directory name to autodiscover in bundles.')
+                            ->prototype('array')
+                                ->prototype('scalar')->end()
+                            ->end()
+                            ->defaultValue(call_user_func(function () {
+                                $defaultValue = ['action' => ['Action']];
+                                if (class_exists(Command::class)) {
+                                    $defaultValue['command'] = ['Command'];
+                                }
+
+                                return $defaultValue;
+                            }))
+                        ->end()
                     ->end()
                 ->end()
                 ->arrayNode('directories')
-                    ->info('List of directories relative to the kernel root directory containing action classes.')
-                    ->prototype('scalar')->end()
+                    ->info('List of directories relative to the kernel root directory containing classes.')
+                    ->prototype('array')
+                        ->prototype('scalar')->end()
+                    ->end()
                     ->defaultValue([])
                 ->end()
             ->end()

--- a/DependencyInjection/DunglasActionExtension.php
+++ b/DependencyInjection/DunglasActionExtension.php
@@ -30,7 +30,7 @@ class DunglasActionExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('dunglas_action.autodiscover.enabled', $config['autodiscover']['enabled']);
-        $container->setParameter('dunglas_action.autodiscover.directory', $config['autodiscover']['directory']);
+        $container->setParameter('dunglas_action.autodiscover.directories', $config['autodiscover']['directories']);
         $container->setParameter('dunglas_action.directories', $config['directories']);
 
         if (class_exists('Symfony\Component\Routing\Loader\AnnotationDirectoryLoader')) {

--- a/DunglasActionBundle.php
+++ b/DunglasActionBundle.php
@@ -23,6 +23,12 @@ final class DunglasActionBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new RegisterCompilerPass());
+        $passConfig = $container->getCompilerPassConfig();
+
+        $passes = $passConfig->getBeforeOptimizationPasses();
+
+        // This pass must be executed before AddConsoleCommandPass from the FrameworkBundle
+        array_unshift($passes, new RegisterCompilerPass());
+        $passConfig->setBeforeOptimizationPasses($passes);
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,20 +6,19 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/dunglas/DunglasActionBundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/dunglas/DunglasActionBundle/?branch=master)
 [![StyleCI](https://styleci.io/repos/50048652/shield)](https://styleci.io/repos/50048652)
 
-This bundle is a replacement for [the controller system](https://symfony.com/doc/current/book/controller.html) of the [Symfony framework](https://symfony.com).
+This bundle is a replacement for [the controller system](https://symfony.com/doc/current/book/controller.html) of the [Symfony framework](https://symfony.com) and for its [command system](https://symfony.com/doc/current/cookbook/console/console_command.html).
 
 It is as convenient as the original but doesn't suffer from its drawbacks:
 
-* Action classes are automatically **registered as services** by the bundle
-* Dependencies of action classes are **explicitly injected** in the constructor (no more ugly access to the service container)
-* Dependencies of action classes are **automatically injected** using the [autowiring feature of the Dependency Injection Component](https://dunglas.fr/2015/10/new-in-symfony-2-83-0-services-autowiring/)
+* Action and ``Command`` classes are automatically **registered as services** by the bundle
+* Their dependencies are **explicitly injected** in the constructor (no more ugly access to the service container) using the [autowiring feature of the Dependency Injection Component](https://dunglas.fr/2015/10/new-in-symfony-2-83-0-services-autowiring/)
 * Only one action per class thanks to the [`__invoke()` method](http://php.net/manual/en/language.oop5.magic.php#object.invoke)
   (but you're still free to create classes with more than 1 action if you want to)
 * 100% compatible with common libraries and bundles including [SensioFrameworkExtraBundle](https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/)
   annotations
 
 DunglasActionBundle allows to create **reusable**, **framework agnostic** (especially when used with [the PSR-7 bridge](https://dunglas.fr/2015/06/using-psr-7-in-symfony/))
-and **easy to unit test** actions.
+and **easy to unit test** classes.
 
 See https://github.com/symfony/symfony/pull/16863#issuecomment-162221353 for the history behind this bundle.
 
@@ -109,6 +108,8 @@ By convention, those services follow this pattern: `action.The\Fully\Qualified\C
 
 For instance, the class in the example is automatically registered with the name `action.AppBundle\Action\MyAction`.
 
+The ``Command``s located in the `Command` directory of your bundles are registered as services as `command.The\Fully\Qualified\Class\Name`.
+
 Thanks to the [autowiring feature](http://symfony.com/blog/new-in-symfony-2-8-service-auto-wiring) of the Dependency Injection
 Component, you can just typehint dependencies you need in the constructor, they will be automatically injected.
 
@@ -122,6 +123,12 @@ services:
     'action.AppBundle\Action\MyAction':
         class: 'AppBundle\Action\MyAction'
         arguments: [ '@router', '@twig' ]
+
+    'command.AppBundle\Command\MyCommand':
+        class: 'AppBundle\Command\MyCommand'
+        arguments: [ '@router', '@twig' ]
+        tags:
+            - { name: console.command }
 ```
 
 This bundle also hooks into the Routing Component (if it is available): when the `@Route` annotation is used as in the example,
@@ -186,9 +193,11 @@ dunglas_action:
     autodiscover:         # Autodiscover action classes stored in the configured directory of bundles and register them as service.
         enabled:   true
         directories: # The directories name to autodiscover in bundles.
-            action: [ Action ]
-            command: [ Command ]
-    directories:   []     # List of directories relative to the kernel root directory containing action classes.
+            action: [ Action ]   # Automatically adapted in the routing
+            command: [ Command ] # Automatically tagged
+            foo: [ Foo ]         # Only registered
+    directories:         # List of directories relative to the kernel root directory containing classes to auto-register.
+        command: [ '../src/MyBundle/My/Uncommon/Directory' ]
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ Want to see a more advanced example? [Checkout our test micro kernel](Tests/Fixt
 dunglas_action:
     autodiscover:         # Autodiscover action classes stored in the configured directory of bundles and register them as service.
         enabled:   true
-        directory: Action # The directory name to autodiscover in bundles.
+        directories: # The directories name to autodiscover in bundles.
+            action: [ Action ]
+            command: [ Command ]
     directories:   []     # List of directories relative to the kernel root directory containing action classes.
 ```
 

--- a/Tests/CommandRegistrationTest.php
+++ b/Tests/CommandRegistrationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Dunglas\ActionBundle\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @author Ener-Getick <egetick@gmail.com>
+ */
+class CommandRegistrationTest extends KernelTestCase
+{
+    public function testCommandRegistrationAction()
+    {
+        static::bootKernel();
+
+        $commandId = 'command.dunglas\actionbundle\tests\fixtures\command\foocommand';
+        $this->assertTrue(static::$kernel->getContainer()->has($commandId));
+
+        $this->assertContains($commandId, static::$kernel->getContainer()->getParameter('console.command.ids'));
+    }
+}

--- a/Tests/Fixtures/TestBundle/Command/FooCommand.php
+++ b/Tests/Fixtures/TestBundle/Command/FooCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Dunglas\ActionBundle\Tests\Fixtures\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+class FooCommand extends Command
+{
+}

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -64,7 +64,7 @@ final class TestKernel extends Kernel
         ]);
 
         $c->loadFromExtension('dunglas_action', [
-            'directories' => ['IsolatedAction'],
+            'directories' => ['action' => ['IsolatedAction']],
         ]);
 
         $c->register('action.Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Action\OverrideAction', 'Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Action\OverrideAction');

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "symfony/framework-bundle": "~2.8|~3.0",
     "symfony/browser-kit": "~2.8|~3.0",
     "symfony/expression-language": "~2.8|~3.0",
+    "symfony/console": "~2.8|~3.0",
     "sensio/framework-extra-bundle": "~3.0"
   },
   "suggest": {


### PR DESCRIPTION
See https://github.com/dunglas/DunglasActionBundle/pull/12#issuecomment-193885914

Allow to auto-register commands:
```yml
dunglas_action:
    directories:
        action:
            - Foo/Bar
        command: 
            - FooBar
    autodiscover:
        directories:
            action: [ Action ]
            command: [ Command ]
```