### PR TITLE
Fix #16

### DIFF
--- a/DependencyInjection/CompilerPass/RegisterCompilerPass.php
+++ b/DependencyInjection/CompilerPass/RegisterCompilerPass.php
@@ -9,6 +9,7 @@
 
 namespace Dunglas\ActionBundle\DependencyInjection\CompilerPass;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -119,6 +120,10 @@ final class RegisterCompilerPass implements CompilerPassInterface
             $reflectionClass = new \ReflectionClass($className);
             $sourceFile = $reflectionClass->getFileName();
 
+            if ($reflectionClass->isAbstract()) {
+                continue;
+            }
+
             if (isset($includedFiles[$sourceFile])) {
                 $classes[$className] = true;
             }
@@ -135,6 +140,10 @@ final class RegisterCompilerPass implements CompilerPassInterface
      */
     private function registerClass(ContainerBuilder $container, $prefix, $className)
     {
+        if ('command' === $prefix && !is_subclass_of($className, Command::class)) {
+            return;
+        }
+
         $id = sprintf('%s.%s', $prefix, $className);
 
         if ($container->has($id)) {

--- a/Tests/CommandRegistrationTest.php
+++ b/Tests/CommandRegistrationTest.php
@@ -20,9 +20,11 @@ class CommandRegistrationTest extends KernelTestCase
     {
         static::bootKernel();
 
-        $commandId = 'command.dunglas\actionbundle\tests\fixtures\command\foocommand';
+        $commandId = 'command.dunglas\actionbundle\tests\fixtures\testbundle\command\foocommand';
         $this->assertTrue(static::$kernel->getContainer()->has($commandId));
 
         $this->assertContains($commandId, static::$kernel->getContainer()->getParameter('console.command.ids'));
+
+        $this->assertFalse(static::$kernel->getContainer()->has('command.dunglas\actionbundle\tests\fixtures\testbundle\command\bar'));
     }
 }

--- a/Tests/Fixtures/TestBundle/Action/AbstractAction.php
+++ b/Tests/Fixtures/TestBundle/Action/AbstractAction.php
@@ -7,10 +7,8 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Command;
+namespace Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Action;
 
-use Symfony\Component\Console\Command\Command;
-
-class FooCommand extends Command
+abstract class AbstractAction
 {
 }

--- a/Tests/Fixtures/TestBundle/Command/Bar.php
+++ b/Tests/Fixtures/TestBundle/Command/Bar.php
@@ -9,8 +9,6 @@
 
 namespace Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Command;
 
-use Symfony\Component\Console\Command\Command;
-
-class FooCommand extends Command
+class Bar
 {
 }

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -74,4 +74,10 @@ class FunctionalTest extends WebTestCase
         $crawler = $client->request('GET', '/isolated');
         $this->assertSame('Isolated.', $crawler->text());
     }
+
+    public function testAbstractClassNotRegistered()
+    {
+        static::bootKernel();
+        $this->assertFalse(static::$kernel->getContainer()->has('action.dunglas\actionBundle\tests\fixtures\testbundle\action\abstractaction'));
+    }
 }


### PR DESCRIPTION
Add a check to ensure that the classes registered are not abstract and that the commands extend the base Command class (see #16).

Edit: tested with the standard edition