### PR TITLE
Remove useless code

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -53,7 +53,6 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->prototype('scalar')->end()
                     ->end()
-                    ->defaultValue([])
                 ->end()
             ->end()
         ->end();


### PR DESCRIPTION
Prototyped arrays always have default to an empty array (unless defaulting to another array explicitly)