### PR TITLE
Fix the configuration for prototyped arrays used as map

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->arrayNode('directories')
                             ->info('The directory name to autodiscover in bundles.')
+                            ->useAttributeAsKey('prefix')
                             ->prototype('array')
                                 ->prototype('scalar')->end()
                             ->end()


### PR DESCRIPTION
Without using ``useAttributeAsKey``, the prototyped node is considered as a list, not as a map, and keys are lost when merging multiple config files.
Currently, a bug in Symfony means that keys are not lost when the merging does not happen (a call to ``array_values`` is missing in the "optimized" code path), which means that you will discover the bug in your config only once someone tries to overwrite the config in a subsequent config file. I missed the opportunity to fix the bug in Symfony 3 (fixing it breaks BC as many people rely on it due to misunderstanding the config component and not trying to overwrite the config in different environments to reveal the bug).
As a side note, this makes it closer to support XML configuration for your bundle (relying on the default example.org XML namespace generated by Symfony as you don't provide another one), which was not possible before (as the map key could not be provided without this). There is still a few missing things for complete XML config (I will send another PR for that)