### PR TITLE
Add missing configuration for XML support for prototyped nodes

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,10 +27,12 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder();
         $treeBuilder->root('dunglas_action')
+            ->fixXmlConfig('directory', 'directories')
             ->children()
                 ->arrayNode('autodiscover')
                     ->info('Autodiscover action classes stored in the configured directory of bundles and register them as service.')
                     ->canBeDisabled()
+                    ->fixXmlConfig('directory', 'directories')
                     ->children()
                         ->arrayNode('directories')
                             ->info('The directory name to autodiscover in bundles.')


### PR DESCRIPTION
Note that the second argument is necessary here, because the plural is not just a matter of adding a ``s`` at the end.