### PR TITLE
Fix the configuration for prototyped arrays used as map

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -51,6 +51,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('directories')
                     ->info('List of directories relative to the kernel root directory containing classes.')
+                    ->useAttributeAsKey('prefix')
                     ->prototype('array')
                         ->prototype('scalar')->end()
                     ->end()


### PR DESCRIPTION
In #23, I fixed one of the prototyped nodes, but I missed the fact that the other one is also using a map, and so suffered from the same issue.