### PR TITLE
Support traditional Symfony conventions

### DIFF
--- a/DependencyInjection/CompilerPass/RegisterCompilerPass.php
+++ b/DependencyInjection/CompilerPass/RegisterCompilerPass.php
@@ -39,16 +39,6 @@ final class RegisterCompilerPass implements CompilerPassInterface
             }
         }
 
-        if ($container->getParameter('dunglas_action.autodiscover.enabled')) {
-            foreach ($container->getParameter('dunglas_action.autodiscover.directories') as $prefix => $dirs) {
-                if (!isset($directories[$prefix])) {
-                    $directories[$prefix] = [];
-                }
-
-                $directories[$prefix] = array_merge($directories[$prefix], $this->getAutodiscoveredDirectories($container, $dirs));
-            }
-        }
-
         foreach ($directories as $prefix => $dirs) {
             foreach ($dirs as $directory) {
                 foreach ($this->getClasses($directory) as $class) {
@@ -56,33 +46,6 @@ final class RegisterCompilerPass implements CompilerPassInterface
                 }
             }
         }
-    }
-
-    /**
-     * Gets the list of directories to autodiscover.
-     *
-     * @param ContainerBuilder $container
-     * @param string[]         $dirs
-     *
-     * @return array
-     */
-    private function getAutodiscoveredDirectories(ContainerBuilder $container, $dirs)
-    {
-        $directories = [];
-
-        foreach ($container->getParameter('kernel.bundles') as $bundle) {
-            $reflectionClass = new \ReflectionClass($bundle);
-            $bundleDirectory = dirname($reflectionClass->getFileName());
-            foreach ($dirs as $directory) {
-                $actionDirectory = $bundleDirectory.DIRECTORY_SEPARATOR.$directory;
-
-                if (file_exists($actionDirectory)) {
-                    $directories[] = $actionDirectory;
-                }
-            }
-        }
-
-        return $directories;
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,35 +29,16 @@ class Configuration implements ConfigurationInterface
         $treeBuilder->root('dunglas_action')
             ->fixXmlConfig('directory', 'directories')
             ->children()
-                ->arrayNode('autodiscover')
-                    ->info('Autodiscover action classes stored in the configured directory of bundles and register them as service.')
-                    ->canBeDisabled()
-                    ->fixXmlConfig('directory', 'directories')
-                    ->children()
-                        ->arrayNode('directories')
-                            ->info('The directory name to autodiscover in bundles.')
-                            ->useAttributeAsKey('prefix')
-                            ->prototype('array')
-                                ->prototype('scalar')->end()
-                            ->end()
-                            ->defaultValue(['controller' => ['Action']])
-                        ->end()
-                    ->end()
-                ->end()
                 ->arrayNode('directories')
                     ->info('List of directories relative to the kernel root directory containing classes.')
                     ->useAttributeAsKey('prefix')
                     ->prototype('array')
                         ->prototype('scalar')->end()
                     ->end()
-                    ->defaultValue(call_user_func(function () {
-                        $defaultValue = ['controller' => ['../src/*Bundle/Controller']];
-                        if (class_exists(Command::class)) {
-                            $defaultValue['command'] = ['../src/*Bundle/Command'];
-                        }
-
-                        return $defaultValue;
-                    }))
+                    ->defaultValue([
+                        'controller' => ['../src/*Bundle/Controller', '../src/*Bundle/Action'],
+                        'command' => ['../src/*Bundle/Command'],
+                    ])
                 ->end()
             ->end()
         ->end();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,14 +40,7 @@ class Configuration implements ConfigurationInterface
                             ->prototype('array')
                                 ->prototype('scalar')->end()
                             ->end()
-                            ->defaultValue(call_user_func(function () {
-                                $defaultValue = ['action' => ['Action']];
-                                if (class_exists(Command::class)) {
-                                    $defaultValue['console'] = ['Console'];
-                                }
-
-                                return $defaultValue;
-                            }))
+                            ->defaultValue(['controller' => ['Action']])
                         ->end()
                     ->end()
                 ->end()
@@ -57,6 +50,14 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->prototype('scalar')->end()
                     ->end()
+                    ->defaultValue(call_user_func(function () {
+                        $defaultValue = ['controller' => ['../src/*Bundle/Controller']];
+                        if (class_exists(Command::class)) {
+                            $defaultValue['command'] = ['../src/*Bundle/Command'];
+                        }
+
+                        return $defaultValue;
+                    }))
                 ->end()
             ->end()
         ->end();

--- a/DependencyInjection/DunglasActionExtension.php
+++ b/DependencyInjection/DunglasActionExtension.php
@@ -29,8 +29,6 @@ class DunglasActionExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter('dunglas_action.autodiscover.enabled', $config['autodiscover']['enabled']);
-        $container->setParameter('dunglas_action.autodiscover.directories', $config['autodiscover']['directories']);
         $container->setParameter('dunglas_action.directories', $config['directories']);
 
         if (class_exists('Symfony\Component\Routing\Loader\AnnotationDirectoryLoader')) {

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ class MyAction
 **There is no step 2! You're already done.**
 
 All classes inside of the `Action/` directory of your project bundles are automatically registered as services.
-By convention, those services follow this pattern: `action.The\Fully\Qualified\Class\Name`.
+By convention, those services follow this pattern: `controller.The\Fully\Qualified\Class\Name`.
 
-For instance, the class in the example is automatically registered with the name `action.AppBundle\Action\MyAction`.
+For instance, the class in the example is automatically registered with the name `controller.AppBundle\Action\MyAction`.
 
-The ``Command``s located in the `Console` directory of your bundles are registered as services as `console.The\Fully\Qualified\Class\Name`.
+The ``Command``s located in the `Command` directory of your bundles are registered as services as `command.The\Fully\Qualified\Class\Name`.
 
 Thanks to the [autowiring feature](http://symfony.com/blog/new-in-symfony-2-8-service-auto-wiring) of the Dependency Injection
 Component, you can just typehint dependencies you need in the constructor, they will be automatically injected.
@@ -120,12 +120,12 @@ Service definition can easily be customized by explicitly defining a service nam
 
 services:
     # This is a custom service definition
-    'action.AppBundle\Action\MyAction':
+    'controller.AppBundle\Action\MyAction':
         class: 'AppBundle\Action\MyAction'
         arguments: [ '@router', '@twig' ]
 
-    'console.AppBundle\Console\MyCommand':
-        class: 'AppBundle\Console\MyCommand'
+    'command.AppBundle\Command\MyCommand':
+        class: 'AppBundle\Command\MyCommand'
         arguments: [ '@router', '@twig' ]
         tags:
             - { name: console.command }
@@ -168,7 +168,7 @@ final class MyMicroKernel extends Kernel
     protected function configureRoutes(RouteCollectionBuilder $routes)
     {
         // Specify explicitly the controller
-        $routes->add('/', 'action.AppBundle\Action\MyAction', 'my_route');
+        $routes->add('/', 'controller.AppBundle\Action\MyAction', 'my_route');
         // Alternatively, use @Route annotations
         // $routes->import('@AppBundle/Action/', '/', 'action-annotation');
     }
@@ -193,11 +193,12 @@ dunglas_action:
     autodiscover:         # Autodiscover action classes stored in the configured directory of bundles and register them as service.
         enabled:   true
         directories: # The directories name to autodiscover in bundles.
-            action: [ Action ]   # Automatically adapted in the routing
-            console: [ Console ] # Automatically tagged
-            foo: [ Foo ]         # Only registered
-    directories:         # List of directories relative to the kernel root directory containing classes to auto-register.
-        console: [ '../src/MyBundle/My/Uncommon/Directory' ]
+            controller: [ Action ] # Automatically adapted in the routing
+            command: [ Console ] # Automatically tagged
+            foo: [ Foo ] # All class in this directory will be registered as services
+    directories: # List of directories relative to the kernel root directory containing classes to auto-register.
+        controller: [ '../src/*Bundle/My/Uncommon/Directory' ]
+        command: [ '../src/*Bundle/My/Other/Uncommon/Directory' ]
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Optional: to use the `@Route` annotation add the following lines in `app/config/
 
 ```yaml
 app_action:
-    resource: '@AppBundle/Action/'
+    resource: '@AppBundle/Action/' # Use @AppBundle/Controller/ if you prefer
     type:     'action-annotation'
 ```
 
@@ -101,17 +101,21 @@ class MyAction
 }
 ```
 
+Alternatively, you can create typical controller class with several `*Action` methods in the `Controller` directory of your
+bundle, it will be autowired the same way.
+
 **There is no step 2! You're already done.**
 
-All classes inside of the `Action/` directory of your project bundles are automatically registered as services.
+All classes inside `Action/` and `Controller/` directories of your project bundles are automatically registered as services.
 By convention, those services follow this pattern: `controller.The\Fully\Qualified\Class\Name`.
 
 For instance, the class in the example is automatically registered with the name `controller.AppBundle\Action\MyAction`.
 
-The ``Command``s located in the `Command` directory of your bundles are registered as services as `command.The\Fully\Qualified\Class\Name`.
+`Command`'s located in the `Command` directory of your bundles are also registered as services. Services name looks like
+`command.The\Fully\Qualified\Class\Name`.
 
 Thanks to the [autowiring feature](http://symfony.com/blog/new-in-symfony-2-8-service-auto-wiring) of the Dependency Injection
-Component, you can just typehint dependencies you need in the constructor, they will be automatically injected.
+Component, you can just typehint dependencies you need in the constructor, they will be automatically initialized and injected.
 
 Service definition can easily be customized by explicitly defining a service named according to the same convention:
 
@@ -190,15 +194,9 @@ Want to see a more advanced example? [Checkout our test micro kernel](Tests/Fixt
 # app/config/config.yml
 
 dunglas_action:
-    autodiscover:         # Autodiscover action classes stored in the configured directory of bundles and register them as service.
-        enabled:   true
-        directories: # The directories name to autodiscover in bundles.
-            controller: [ Action ] # Automatically adapted in the routing
-            command: [ Console ] # Automatically tagged
-            foo: [ Foo ] # All class in this directory will be registered as services
     directories: # List of directories relative to the kernel root directory containing classes to auto-register.
-        controller: [ '../src/*Bundle/My/Uncommon/Directory' ]
-        command: [ '../src/*Bundle/My/Other/Uncommon/Directory' ]
+        controller: [ '../src/*Bundle/Controller', '../src/*Bundle/Action', '../src/*Bundle/My/Uncommon/Directory' ]
+        command: [ '../src/*Bundle/Command', '../src/*Bundle/My/Other/Uncommon/Directory' ]
 ```
 
 ## Credits

--- a/Routing/AnnotationClassLoader.php
+++ b/Routing/AnnotationClassLoader.php
@@ -24,7 +24,7 @@ class AnnotationClassLoader extends BaseAnnotationClassLoader
      */
     protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
     {
-        $route->setDefault('_controller', 'action.'.$class->name.':'.$method->name);
+        $route->setDefault('_controller', 'controller.'.$class->name.':'.$method->name);
     }
 
     /**
@@ -32,6 +32,6 @@ class AnnotationClassLoader extends BaseAnnotationClassLoader
      */
     public function supports($resource, $type = null)
     {
-        return 'action-annotation' === $type && parent::supports($resource) && false !== strpos($resource, '\Action');
+        return 'action-annotation' === $type && parent::supports($resource);
     }
 }

--- a/Tests/CommandRegistrationTest.php
+++ b/Tests/CommandRegistrationTest.php
@@ -19,12 +19,13 @@ class CommandRegistrationTest extends KernelTestCase
     public function testCommandRegistrationAction()
     {
         static::bootKernel();
+        $container = static::$kernel->getContainer();
 
-        $commandId = 'console.dunglas\actionbundle\tests\fixtures\testbundle\console\foocommand';
-        $this->assertTrue(static::$kernel->getContainer()->has($commandId));
+        $commandId = 'command.dunglas\actionbundle\tests\fixtures\testbundle\command\foocommand';
+        $this->assertTrue($container->has($commandId));
 
-        $this->assertContains($commandId, static::$kernel->getContainer()->getParameter('console.command.ids'));
+        $this->assertContains($commandId, $container->getParameter('console.command.ids'));
 
-        $this->assertFalse(static::$kernel->getContainer()->has('console.dunglas\actionbundle\tests\fixtures\testbundle\console\bar'));
+        $this->assertFalse($container->has('command.dunglas\actionbundle\tests\fixtures\testbundle\command\bar'));
     }
 }

--- a/Tests/Fixtures/TestBundle/Command/Bar.php
+++ b/Tests/Fixtures/TestBundle/Command/Bar.php
@@ -7,10 +7,8 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Console;
+namespace Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Command;
 
-use Symfony\Component\Console\Command\Command;
-
-class FooCommand extends Command
+class Bar
 {
 }

--- a/Tests/Fixtures/TestBundle/Command/FooCommand.php
+++ b/Tests/Fixtures/TestBundle/Command/FooCommand.php
@@ -7,8 +7,10 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Console;
+namespace Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Command;
 
-class Bar
+use Symfony\Component\Console\Command\Command;
+
+class FooCommand extends Command
 {
 }

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -43,14 +43,14 @@ final class TestKernel extends Kernel
     protected function configureRoutes(RouteCollectionBuilder $routes)
     {
         // Specify explicitly the controller
-        $routes->add('/', 'action.Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Action\DummyAction', 'dummy');
-        $routes->add('/isolated', 'action.Dunglas\ActionBundle\Tests\Fixtures\IsolatedAction\AnIsolatedAction', 'isolated');
+        $routes->add('/', 'controller.Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Action\DummyAction', 'dummy');
+        $routes->add('/isolated', 'controller.Dunglas\ActionBundle\Tests\Fixtures\IsolatedAction\AnIsolatedAction', 'isolated');
 
         // Use the @Route annotation
         $routes->import('@TestBundle/Action/', '/', 'action-annotation');
 
         // Cohabitation between old school controllers and actions
-        $routes->import('@TestBundle/Controller/', '/', 'annotation');
+        $routes->import('@TestBundle/Controller/', '/', 'action-annotation');
     }
 
     /**
@@ -64,9 +64,12 @@ final class TestKernel extends Kernel
         ]);
 
         $c->loadFromExtension('dunglas_action', [
-            'directories' => ['action' => ['IsolatedAction']],
+            'directories' => [
+                'controller' => ['*Bundle/Controller', 'IsolatedAction'],
+                'command' => ['*Bundle/Command'],
+            ],
         ]);
 
-        $c->register('action.Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Action\OverrideAction', 'Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Action\OverrideAction');
+        $c->register('controller.Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Action\OverrideAction', 'Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Action\OverrideAction');
     }
 }

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -65,7 +65,7 @@ final class TestKernel extends Kernel
 
         $c->loadFromExtension('dunglas_action', [
             'directories' => [
-                'controller' => ['*Bundle/Controller', 'IsolatedAction'],
+                'controller' => ['*Bundle/Controller', '*Bundle/Action', 'IsolatedAction'],
                 'command' => ['*Bundle/Command'],
             ],
         ]);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "php": ">=5.5.9",
     "symfony/config": "~2.8|~3.0",
     "symfony/dependency-injection": "~2.8|~3.0",
-    "symfony/http-kernel": "~2.8|~3.0"
+    "symfony/http-kernel": "~2.8|~3.0",
+    "symfony/finder": "~2.8|~3.0"
   },
   "require-dev": {
     "symfony/framework-bundle": "~2.8|~3.0",


### PR DESCRIPTION
* Register controllers in `src/*Bundle/Controller` and `src/*Bundle/Action`
* Register commands in `src/*Bundle/Command` (and no more in `Console`)
* Use the Symfony Finder to allow smart path scanning
* Remove the "autodiscover" feature

cc @Ener-Getick 