### PR TITLE
Support standard annotation type in prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,17 @@ public function registerBundles()
 Optional: to use the `@Route` annotation add the following lines in `app/config/routing.yml`:
 
 ```yaml
-app_action:
+app:
     resource: '@AppBundle/Action/' # Use @AppBundle/Controller/ if you prefer
-    type:     'action-annotation'
+    type:     'annotation'
+```
+
+If you don't want to use annotations but prefer raw YAML, use the following syntax:
+
+```yaml
+foo:
+    path:      /foo/{bar}
+    defaults:  { _controller: 'controller.Path\To\Your\Action' } # this is the name of the autoregistered service corresponding to this controller
 ```
 
 ## Usage

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -9,6 +9,7 @@
         <service id="dunglas_action.routing.loader.annot_dir" class="Dunglas\ActionBundle\Routing\AnnotationDirectoryLoader" public="false">
             <argument type="service" id="file_locator" />
             <argument type="service" id="dunglas_action.routing.loader.annot_class" />
+            <argument>%dunglas_action.scanned_directories%</argument>
 
             <tag name="routing.loader" />
         </service>
@@ -16,6 +17,7 @@
         <service id="dunglas_action.routing.loader.annot_file" class="Dunglas\ActionBundle\Routing\AnnotationFileLoader" public="false">
             <argument type="service" id="file_locator" />
             <argument type="service" id="dunglas_action.routing.loader.annot_class" />
+            <argument>%dunglas_action.scanned_directories%</argument>
 
             <tag name="routing.loader" />
         </service>

--- a/Routing/AnnotationClassLoader.php
+++ b/Routing/AnnotationClassLoader.php
@@ -24,14 +24,6 @@ class AnnotationClassLoader extends BaseAnnotationClassLoader
      */
     protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
     {
-        $route->setDefault('_controller', 'controller.'.$class->name.':'.$method->name);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supports($resource, $type = null)
-    {
-        return 'action-annotation' === $type && parent::supports($resource);
+        $route->setDefault('_controller', sprintf('controller.%s:%s', $class->name, $method->name));
     }
 }

--- a/Routing/AnnotationDirectoryLoader.php
+++ b/Routing/AnnotationDirectoryLoader.php
@@ -9,6 +9,8 @@
 
 namespace Dunglas\ActionBundle\Routing;
 
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
 use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader as BaseAnnotationDirectoryLoader;
 
 /**
@@ -18,11 +20,30 @@ use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader as BaseAnnotation
  */
 class AnnotationDirectoryLoader extends BaseAnnotationDirectoryLoader
 {
+    private $scannedDirectories;
+
+    public function __construct(FileLocatorInterface $locator, AnnotationClassLoader $loader, array $scannedDirectories)
+    {
+        parent::__construct($locator, $loader);
+
+        $this->scannedDirectories = $scannedDirectories;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function supports($resource, $type = null)
     {
-        return 'action-annotation' === $type && parent::supports($resource);
+        if (!parent::supports($resource, $type)) {
+            return false;
+        }
+
+        try {
+            $path = $this->locator->locate($resource);
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return isset($this->scannedDirectories[rtrim($path, '/')]);
     }
 }

--- a/Routing/AnnotationFileLoader.php
+++ b/Routing/AnnotationFileLoader.php
@@ -9,6 +9,8 @@
 
 namespace Dunglas\ActionBundle\Routing;
 
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
 use Symfony\Component\Routing\Loader\AnnotationFileLoader as BaseAnnotationFileLoader;
 
 /**
@@ -18,11 +20,30 @@ use Symfony\Component\Routing\Loader\AnnotationFileLoader as BaseAnnotationFileL
  */
 class AnnotationFileLoader extends BaseAnnotationFileLoader
 {
+    private $scannedDirectories;
+
+    public function __construct(FileLocatorInterface $locator, AnnotationClassLoader $loader, array $scannedDirectories)
+    {
+        parent::__construct($locator, $loader);
+
+        $this->scannedDirectories = $scannedDirectories;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function supports($resource, $type = null)
     {
-        return 'action-annotation' === $type && parent::supports($resource);
+        if (!parent::supports($resource, $type)) {
+            return false;
+        }
+
+        try {
+            $path = $this->locator->locate($resource);
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return isset($this->scannedDirectories[dirname($path)]);
     }
 }

--- a/Tests/Fixtures/NotScannedBundle/Controller/MyController.php
+++ b/Tests/Fixtures/NotScannedBundle/Controller/MyController.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Dunglas\ActionBundle\Tests\Fixtures\NotScannedBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class MyController extends Controller
+{
+    /**
+     * @Route("/traditional")
+     */
+    public function testAction()
+    {
+        return new Response('traditional');
+    }
+}

--- a/Tests/Fixtures/NotScannedBundle/NotScannedBundle.php
+++ b/Tests/Fixtures/NotScannedBundle/NotScannedBundle.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Dunglas\ActionBundle\Tests\Fixtures\NotScannedBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class NotScannedBundle extends Bundle
+{
+}

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -8,6 +8,7 @@
  */
 
 use Dunglas\ActionBundle\DunglasActionBundle;
+use Dunglas\ActionBundle\Tests\Fixtures\NotScannedBundle\NotScannedBundle;
 use Dunglas\ActionBundle\Tests\Fixtures\TestBundle\TestBundle;
 use Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -34,6 +35,7 @@ final class TestKernel extends Kernel
             new DunglasActionBundle(),
             new SensioFrameworkExtraBundle(),
             new TestBundle(),
+            new NotScannedBundle(),
         ];
     }
 
@@ -47,10 +49,11 @@ final class TestKernel extends Kernel
         $routes->add('/isolated', 'controller.Dunglas\ActionBundle\Tests\Fixtures\IsolatedAction\AnIsolatedAction', 'isolated');
 
         // Use the @Route annotation
-        $routes->import('@TestBundle/Action/', '/', 'action-annotation');
+        $routes->import('@TestBundle/Action/', '/', 'annotation');
 
         // Cohabitation between old school controllers and actions
-        $routes->import('@TestBundle/Controller/', '/', 'action-annotation');
+        $routes->import('@TestBundle/Controller/', '/', 'annotation');
+        $routes->import('@NotScannedBundle/Controller/', '/', 'annotation');
     }
 
     /**
@@ -65,7 +68,7 @@ final class TestKernel extends Kernel
 
         $c->loadFromExtension('dunglas_action', [
             'directories' => [
-                'controller' => ['*Bundle/Controller', '*Bundle/Action', 'IsolatedAction'],
+                'controller' => ['TestBundle/Controller', '*Bundle/Action', 'IsolatedAction'],
                 'command' => ['*Bundle/Command'],
             ],
         ]);

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -80,4 +80,12 @@ class FunctionalTest extends WebTestCase
         static::bootKernel();
         $this->assertFalse(static::$kernel->getContainer()->has('action.dunglas\actionBundle\tests\fixtures\testbundle\action\abstractaction'));
     }
+
+    public function testCanAccessTraditionalController()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/traditional');
+        $this->assertSame('traditional', $crawler->text());
+    }
 }


### PR DESCRIPTION
As only user bundles are now scanned, this is not necessary to use another prefix anymore.