### PR TITLE
Disable route loader when SF >= 3.1

### DIFF
--- a/DependencyInjection/DunglasActionExtension.php
+++ b/DependencyInjection/DunglasActionExtension.php
@@ -9,10 +9,13 @@
 
 namespace Dunglas\ActionBundle\DependencyInjection;
 
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -51,7 +54,7 @@ class DunglasActionExtension extends Extension
 
         $container->setParameter('dunglas_action.directories', $directories);
 
-        if (class_exists('Symfony\Component\Routing\Loader\AnnotationDirectoryLoader')) {
+        if (class_exists('Symfony\Component\Routing\Loader\AnnotationDirectoryLoader') && method_exists(Controller::class, 'json')) {
             $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
             $loader->load('routing.xml');
         }
@@ -120,6 +123,11 @@ class DunglasActionExtension extends Extension
 
         $definition = $container->register($className, $className);
         $definition->setAutowired(true);
+
+        // Inject the container if applicable
+        if (is_a($className, ContainerAwareInterface::class, true)) {
+            $definition->addMethodCall('setContainer', [new Reference('service_container')]);
+        }
 
         foreach ($tags as $tagClassName => $classTags) {
             if (!is_a($className, $tagClassName, true)) {

--- a/Tests/Fixtures/TestBundle/Controller/HelloController.php
+++ b/Tests/Fixtures/TestBundle/Controller/HelloController.php
@@ -26,6 +26,6 @@ class HelloController extends Controller
      */
     public function testAction()
     {
-        return new Response('Legacy here.');
+        return new Response($this->get('router')->generate('isolated'));
     }
 }

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -66,7 +66,7 @@ class FunctionalTest extends WebTestCase
         $client = static::createClient();
 
         $crawler = $client->request('GET', '/legacy');
-        $this->assertSame('Legacy here.', $crawler->text());
+        $this->assertSame('/isolated', $crawler->text());
     }
 
     public function testIsolated()


### PR DESCRIPTION
The custom route loader isn't necessary anymore in SF >= 3.1