### PR TITLE
Use a pattern to match the default directories

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,10 +34,7 @@ class Configuration implements ConfigurationInterface
                     ->info('List of directories relative to the kernel root directory containing classes.')
                     ->prototype('scalar')->end()
                     ->defaultValue([
-                        '../src/*Bundle/Controller',
-                        '../src/*Bundle/Action',
-                        '../src/*Bundle/Command',
-                        '../src/*Bundle/EventSubscriber',
+                        '../src/*Bundle/{Controller,Action,Command,EventSubscriber}',
                     ])
                 ->end()
                 ->arrayNode('tags')

--- a/README.md
+++ b/README.md
@@ -212,10 +212,7 @@ Want to see a more advanced example? [Checkout our test micro kernel](Tests/Fixt
 
 dunglas_action:
     directories: # List of directories relative to the kernel root directory containing classes to auto-register.
-        - '../src/*Bundle/Controller'
-        - '../src/*Bundle/Action'
-        - '../src/*Bundle/Command'
-        - '../src/*Bundle/EventSubscriber'
+        - '../src/*Bundle/{Controller,Action,Command,EventSubscriber}'
         # This one is not registered by default
         - '../src/*Bundle/My/Uncommon/Directory'
     tags:


### PR DESCRIPTION
Allows to match the default directories with only one line.
It is especially better in the README imo as it allows people to easily separate the default directories from theirs.