### PR TITLE
Update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,52 @@ cache:
     - $HOME/.composer/cache
 
 php:
-    - 5.5
-    - 5.6
-    - 7.0
+    - "5.5"
+    - "5.6"
+    - "7.0"
+    - "7.1"
+    - nightly
     - hhvm
 
 matrix:
     fast_finish: true
     include:
-        - php: 7.0
-          env: SYMFONY_VERSION=2.8.*
-        - php: 7.0
-          env: SYMFONY_VERSION=3.0.*
-        - php: 7.0
+        - php: "5.5"
+          env:
+              - "SYMFONY_VERSION=~2.8.0"
+              - "COMPOSER_FLAGS=--prefer-lowest"
+        - php: "7.0"
+          env: "SYMFONY_VERSION=~3.0.0"
+        - php: "7.0"
+          env: "SYMFONY_VERSION=~3.1.0"
+        - php: "7.0"
+          env: "SYMFONY_VERSION=~3.2.0@dev"
+    allow_failures:
+        - php: nightly
+        - env: "SYMFONY_VERSION=~3.2.0@dev"
 
 before_install:
+    # From https://github.com/travis-ci/travis-ci/issues/5780#issuecomment-196308406
+    - |
+      XDEBUG_INI="/home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini"
+      if [ ! -f "$XDEBUG_INI" ]; then
+          return
+      fi
+      function composer()
+      {
+          mv $XDEBUG_INI ~/xdebug.ini
+          COMPOSER="$(which composer)"
+          $COMPOSER "$@"
+          STATUS=$?
+          mv ~/xdebug.ini $XDEBUG_INI
+
+          return $STATUS
+      }
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+    - if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then COMPOSER_FLAGS="$COMPOSER_FLAGS --ignore-platform-reqs"; fi;
 
 install:
-    - composer update --no-interaction --prefer-dist
+    - composer update $COMPOSER_FLAGS --no-interaction --prefer-dist
 
 script:
     - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ install:
     - composer update $COMPOSER_FLAGS --no-interaction --prefer-dist
 
 script:
-    - phpunit
+    - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5.0||^4.6",
-    "sensio/framework-extra-bundle": "~3.0",
+    "sensio/framework-extra-bundle": "^3.0.10",
     "symfony/console": "~2.8||~3.0",
     "symfony/browser-kit": "~2.8||~3.0",
     "symfony/expression-language": "~2.8||~3.0",

--- a/composer.json
+++ b/composer.json
@@ -13,21 +13,22 @@
     }
   ],
   "require": {
-    "php": ">=5.5.9",
-    "symfony/config": "~2.8|~3.0",
-    "symfony/dependency-injection": "~2.8|~3.0",
-    "symfony/http-kernel": "~2.8|~3.0",
-    "symfony/finder": "~2.8|~3.0"
+    "php": ">=5.5.9 <7.2.0",
+    "symfony/config": "~2.8||~3.0",
+    "symfony/dependency-injection": "~2.8||~3.0",
+    "symfony/finder": "~2.8||~3.0",
+    "symfony/http-kernel": "~2.8||~3.0"
   },
   "require-dev": {
-    "symfony/framework-bundle": "~2.8|~3.0",
-    "symfony/browser-kit": "~2.8|~3.0",
-    "symfony/expression-language": "~2.8|~3.0",
-    "symfony/console": "~2.8|~3.0",
-    "sensio/framework-extra-bundle": "~3.0"
+    "phpunit/phpunit": "^5.0||^4.6",
+    "sensio/framework-extra-bundle": "~3.0",
+    "symfony/console": "~2.8||~3.0",
+    "symfony/browser-kit": "~2.8||~3.0",
+    "symfony/expression-language": "~2.8||~3.0",
+    "symfony/framework-bundle": "~2.8||~3.0"
   },
   "conflict": {
-    "symfony/framework-bundle": "<2.8.5|>3.0,<3.0.5"
+    "symfony/framework-bundle": "<2.8.5||>3.0,<3.0.5"
   },
   "autoload": {
     "psr-4": { "Dunglas\\ActionBundle\\": "" },
@@ -39,5 +40,8 @@
     "branch-alias": {
       "dev-master": "1.0.x-dev"
     }
+  },
+  "config": {
+    "sort-packages": true
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,8 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+
+        <server name="KERNEL_DIR" value="Tests/Fixtures/" />
     </php>
 
     <testsuites>
@@ -16,10 +18,6 @@
             <directory>Tests</directory>
         </testsuite>
     </testsuites>
-
-    <php>
-        <server name="KERNEL_DIR" value="Tests/Fixtures/" />
-    </php>
 
     <filter>
         <whitelist>


### PR DESCRIPTION
- Add new PHP versons to the matrix
- Test new versions of Symfony
- Fix unbound PHP and standardise `composer.json` (Closes https://github.com/dunglas/DunglasActionBundle/pull/51)
- Add a test against lower deps
- Add PHPUnit to the dev deps (as it executes code, it should go under Composer deps resolution)
- Remove unneeded `composer self-update` (Travis now do it in each build)