### PR TITLE
Check absolute links

### DIFF
--- a/DependencyInjection/DunglasActionExtension.php
+++ b/DependencyInjection/DunglasActionExtension.php
@@ -34,8 +34,7 @@ class DunglasActionExtension extends Extension
 
         $directoryList = [];
         foreach ($config['directories'] as $pattern) {
-            $directory = (DIRECTORY_SEPARATOR !== substr($pattern, 0, 1)) ? $kernelRootDir.DIRECTORY_SEPARATOR.$pattern : $pattern;
-            list($classes, $directories) = $this->getClasses($directory);
+            list($classes, $directories) = $this->getClasses($this->getDirectory($kernelRootDir, $pattern));
             $directoryList = array_merge($directoryList, $directories);
 
             foreach ($classes as $class) {
@@ -51,6 +50,19 @@ class DunglasActionExtension extends Extension
         }
 
         $container->setParameter('dunglas_action.directories', $directories);
+    }
+
+    /**
+     * @param string $kernelRootDir
+     * @param string $pattern
+     *
+     * @return string
+     */
+    private function getDirectory($kernelRootDir, $pattern)
+    {
+        $firstCharacter = substr($pattern, 0, 1);
+
+        return ('/' !== $firstCharacter && DIRECTORY_SEPARATOR !== $firstCharacter) ? $kernelRootDir.DIRECTORY_SEPARATOR.$pattern : $pattern;
     }
 
     /**


### PR DESCRIPTION
Follow up of #57. As spotted by @Ener-Getick the absolute link may be given manually by the user (very likely to be `/`) but may also come from the platform (`%kernel.root_dir%`) in which case `DIRECTORY_SEPARATOR` is more appropriate.