### PR TITLE
Bugfix for non GLOB_BRACE exist platforms

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -43,7 +43,7 @@ class Configuration implements ConfigurationInterface
                         '../src/*Bundle/Command',
                         '../src/*Bundle/Controller',
                         '../src/*Bundle/EventSubscriber',
-                        '../src/*Bundle/Twig'
+                        '../src/*Bundle/Twig',
                     ])
                 ->end()
                 ->arrayNode('tags')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,7 +38,13 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('directories')
                     ->info('List of directories relative to the kernel root directory containing classes.')
                     ->prototype('scalar')->end()
-                    ->defaultValue(['../src/*Bundle/{Action,Command,Controller,EventSubscriber,Twig}'])
+                    ->defaultValue([
+                        '../src/*Bundle/Action',
+                        '../src/*Bundle/Command',
+                        '../src/*Bundle/Controller',
+                        '../src/*Bundle/EventSubscriber',
+                        '../src/*Bundle/Twig'
+                    ])
                 ->end()
                 ->arrayNode('tags')
                     ->info('List of tags to add when implementing the corresponding class.')


### PR DESCRIPTION
Popular Docker distro Alpine doesn't support GLOB_BRACE since it is using musl libc instead of GNU libc. I think very hard to debug this issue for developers so basically avoid brace usage.

https://github.com/symfony/finder/blob/master/Finder.php#L543
https://github.com/zendframework/zend-stdlib/issues/58
https://bugs.php.net/bug.php?id=72095
http://ftp.grokbase.com/t/php/php-doc-bugs/164rneeqx3/php-bug-bug-72095-new-undefined-constant-glob-brace-while-doc-base-configure-php