### PR TITLE
Fix #70 (anonymous classes should not be autowired)

### DIFF
--- a/DependencyInjection/DunglasActionExtension.php
+++ b/DependencyInjection/DunglasActionExtension.php
@@ -108,7 +108,7 @@ class DunglasActionExtension extends Extension
                 continue;
             }
 
-            if (version_compare(PHP_VERSION, '7.0.0') >= 0 && $reflectionClass->isAnonymous()) {
+            if (method_exists($reflectionClass, 'isAnonymous') && $reflectionClass->isAnonymous()) {
                 continue;
             }
 

--- a/DependencyInjection/DunglasActionExtension.php
+++ b/DependencyInjection/DunglasActionExtension.php
@@ -108,6 +108,10 @@ class DunglasActionExtension extends Extension
                 continue;
             }
 
+            if (version_compare(PHP_VERSION, '7.0.0') >= 0 && $reflectionClass->isAnonymous()) {
+                continue;
+            }
+
             if (isset($includedFiles[$sourceFile])) {
                 $classes[$className] = true;
             }

--- a/Tests/Fixtures/AnonymousAction/AnAnonymousAction.php
+++ b/Tests/Fixtures/AnonymousAction/AnAnonymousAction.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Dunglas\ActionBundle\Tests\Fixtures\AnonymousAction;
+
+class AnAnonymousAction
+{
+    protected $anonymous;
+
+    public function __construct()
+    {
+        $dummyService = null;
+        $this->anonymous = new class($dummyService) {
+
+            private $dummyService;
+
+            public function __construct($dummyService)
+            {
+                $this->dummyService = $dummyService;
+            }
+        };
+    }
+
+    public function __invoke()
+    {
+        return 'Ho hi';
+    }
+}

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -83,7 +83,7 @@ final class TestKernel extends Kernel
             ],
         ]);
 
-        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+        if (method_exists(ReflectionClass::class, 'isAnonymous')) {
             $c->loadFromExtension('dunglas_action', [
                 'directories' => [
                     'AnonymousAction',

--- a/Tests/Fixtures/TestKernel.php
+++ b/Tests/Fixtures/TestKernel.php
@@ -83,6 +83,14 @@ final class TestKernel extends Kernel
             ],
         ]);
 
+        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+            $c->loadFromExtension('dunglas_action', [
+                'directories' => [
+                    'AnonymousAction',
+                ],
+            ]);
+        }
+
         $c->register(OverrideAction::class, OverrideAction::class);
     }
 }

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -86,25 +86,17 @@ class FunctionalTest extends WebTestCase
         $this->assertFalse(static::$kernel->getContainer()->has('dunglas\actionBundle\tests\fixtures\testbundle\action\abstractaction'));
     }
 
+    /**
+     * @requires PHP 7.0
+     */
     public function testAnonymousClassNotRegistered()
     {
-        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
-            $hasFailed = null;
-            try {
-                static::bootKernel();
-                $this->assertTrue(static::$kernel->getContainer()->has('dunglas\actionBundle\tests\fixtures\anonymousaction\ananonymousaction'));
-                /** @var AnAnonymousAction $action */
-                $action = static::$kernel->getContainer()->get('dunglas\actionBundle\tests\fixtures\anonymousaction\ananonymousaction');
-                $this->assertEquals('Ho hi', $action());
-                $hasFailed = false;
-            } catch (\Symfony\Component\DependencyInjection\Exception\RuntimeException $e) {
-                $hasFailed = true;
-            }
+        static::bootKernel();
+        $this->assertTrue(static::$kernel->getContainer()->has('dunglas\actionBundle\tests\fixtures\anonymousaction\ananonymousaction'));
+        /** @var AnAnonymousAction $action */
+        $action = static::$kernel->getContainer()->get('dunglas\actionBundle\tests\fixtures\anonymousaction\ananonymousaction');
+        $this->assertEquals('Ho hi', $action());
 
-            $this->assertFalse($hasFailed);
-        } else {
-            $this->markTestSkipped('PHP7+ is required to test anonymous classes');
-        }
     }
 
     public function testCanAccessTraditionalController()

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -9,6 +9,7 @@
 
 namespace Dunglas\ActionBundle\Tests;
 
+use Dunglas\ActionBundle\Tests\Fixtures\AnonymousAction\AnAnonymousAction;
 use Dunglas\ActionBundle\Tests\Fixtures\TestBundle\Twig\DummyExtension;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\Definition;
@@ -83,6 +84,27 @@ class FunctionalTest extends WebTestCase
     {
         static::bootKernel();
         $this->assertFalse(static::$kernel->getContainer()->has('dunglas\actionBundle\tests\fixtures\testbundle\action\abstractaction'));
+    }
+
+    public function testAnonymousClassNotRegistered()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+            $hasFailed = null;
+            try {
+                static::bootKernel();
+                $this->assertTrue(static::$kernel->getContainer()->has('dunglas\actionBundle\tests\fixtures\anonymousaction\ananonymousaction'));
+                /** @var AnAnonymousAction $action */
+                $action = static::$kernel->getContainer()->get('dunglas\actionBundle\tests\fixtures\anonymousaction\ananonymousaction');
+                $this->assertEquals('Ho hi', $action());
+                $hasFailed = false;
+            } catch (\Symfony\Component\DependencyInjection\Exception\RuntimeException $e) {
+                $hasFailed = true;
+            }
+
+            $this->assertFalse($hasFailed);
+        } else {
+            $this->markTestSkipped('PHP7+ is required to test anonymous classes');
+        }
     }
 
     public function testCanAccessTraditionalController()


### PR DESCRIPTION
Fixing #70 
On PHP7+, prevent anonymous classes from being autowired.